### PR TITLE
chore(deps): combined Dependabot updates

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,5 +5,5 @@ pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 ruff==0.15.21
-mypy==2.2.0
+mypy==2.3.0
 pip-audit==2.10.1


### PR DESCRIPTION
Combines #254 into one PR so the post-merge checks run once instead of per-PR.

## Included
- #254

## Skipped (same-file conflicts — NOT in this PR; merge individually or re-run `just combine-dependabot` after this merges)
- #253 — chore(deps-dev): bump mypy from 2.2.0 to 2.3.0 in /requirements in the py-minor-patch group across 1 directory (conflict)

After merging this PR: `just close-dependabot-prs <this-pr-number>`

<!-- combined-includes: 254 -->